### PR TITLE
Leave one out validation

### DIFF
--- a/code/src/vizualisation.py
+++ b/code/src/vizualisation.py
@@ -77,9 +77,13 @@ def plot_time_course(
     plt.tight_layout()
     os.makedirs(fig_dir, exist_ok=True)
     plt.savefig(fig_dir / f'{fig_name}.png')
-    plt.savefig(fig_dir / f'{fig_name}.svg')
+    # try-except clause due to my PC having issues with SVG
+    try:
+        plt.savefig(fig_dir / f'{fig_name}.svg')
+    except AttributeError:
+        print(f"Warning: Couldn't save as SVG. Saving as PNG instead for {fig_name}")
+        plt.savefig(fig_dir / f'{fig_name}.pdf')
     plt.close()
-
 
 def plot_PSD_and_SNR(
     psds: np.ndarray,

--- a/code/validate_kokkinakis
+++ b/code/validate_kokkinakis
@@ -5,10 +5,11 @@ from src import preprocessing, classification, vizualisation, utils, spectral_an
 from sklearn.linear_model import LogisticRegression
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.svm import SVC
-from pqdm.processes import pqdm
 import numpy as np
 from pqdm.processes import pqdm
-import json
+from typing import List, Dict
+import pandas as pd
+import pickle
 
 # Declare file locations
 # root_dir = Path.home() / "Git" / "minimap_SSVEPs"
@@ -107,6 +108,7 @@ group_labels = {
 
 
 # These constants have to be somewhat hardcoded due to the need for multiproc functions to be top-level
+## There's a better way to implement this, but let's see if it does what we want it to do first
 MODEL_CLASS = RandomForestClassifier
 K_FOLDS = 5
 RANDOM_STATE = 42
@@ -139,11 +141,13 @@ def parallel_lofo(
         dict: This function technically returns a single dict of dicts, which contains the usual crossval metrics. 
             In the usage below, observe that these dicts are stored in a list, resulting from the multiprocessing.
     """
+    # We have to copy the epochs arrays as drop_channels() is an inplace operation...
     first_epochs_copy = left_minimap_epochs.copy()
     second_epochs_copy = right_minimap_epochs.copy()
-    
-    first_epochs_copy.drop_channels(channel_name, "warn")
-    second_epochs_copy.drop_channels(channel_name, "warn")
+
+    if channel_name != None: 
+        first_epochs_copy.drop_channels(channel_name, "warn")
+        second_epochs_copy.drop_channels(channel_name, "warn")
 
     X_first = classification.compute_psd_and_features(first_epochs_copy) 
     X_second = classification.compute_psd_and_features(second_epochs_copy)
@@ -155,17 +159,56 @@ def parallel_lofo(
     # Perform cross-validation on the training set
     cv_results = classification.perform_cross_validation(X, y, MODEL_CLASS, K_FOLDS, RANDOM_STATE)
     cv_metrics = classification.parse_cv_results(cv_results, K_FOLDS)
-    out = {channel_name: cv_metrics}
-    return out
+    cv_metrics['dropped_channel'] = channel_name
+    return cv_metrics
+    
+def prepare_lofo_features(
+    first_epochs,
+    second_epochs,
+):
+    """prepare_lofo_features is a helper function which grabs the list of channel names for LOFO importance.
+    This also includes an assertion to check that the channel names in both groups match up!
+
+    Args:
+        first_epochs (mne.EpochsArray): The first (either left or right) epochs
+        second_epochs (mne.EpochsArray): The second (either left or right) epochs
+        channel_names (List[str]): The channel names, where each channel is a 'feature' we apply LOFO over
+
+    Returns:
+        List[str]: Channel names extracted directly from the epochs array 
+    """
+    # I think this is a necessary and worthwhile check before running LOFO, since we have two datasets to align.
+    assert first_epochs.ch_names == second_epochs.ch_names
+    channel_names = first_epochs.ch_names
+    channel_names = [None] + channel_names # We include a No feature, as a baseline
+    return channel_names
+    
+def results_to_df(
+    results: list
+) -> pd.DataFrame:
+    parsed = []
+    for result in results:
+        clean = {
+            'dropped_channel' : result['dropped_channel'],
+            'accuracy' : result['aggregated_metrics']['accuracy'],
+            'precision' : result['aggregated_metrics']['precision'],
+            'recall' : result['aggregated_metrics']['recall'],
+            'f1' : result['aggregated_metrics']['f1'],
+            'fold_scores' : result['fold_scores']
+        }
+        parsed.append(clean)
+    return pd.DataFrame(parsed)
 
 if __name__ == "__main__":
 
-    # I think this is a necessary and worthwhile check before running LOFO, since we have two datasets to align.
-    assert left_minimap_epochs.ch_names == right_minimap_epochs.ch_names
-    channel_names = left_minimap_epochs.ch_names
+    channel_names = prepare_lofo_features(left_minimap_epochs, right_minimap_epochs)
 
     # I have chosen to use pqdm to attach a progress bar to this, but using joblib, etc. would be fine too.
-    results = pqdm(channel_names, parallel_lofo, n_jobs=6)
+    results = pqdm(channel_names[:9], parallel_lofo, n_jobs=4)
+    results_df = results_to_df(results)
 
-    with open(logs_dir/"rf_validation.json", "wb") as results_file:
-        json.dump(results, results_file, indent=4)
+    with open(logs_dir/"rf_validation.pickle", "wb") as results_file:
+        pickle.dump(results, results_file)
+    results_df.to_csv(logs_dir/"rf_validation.csv")
+
+

--- a/code/validate_kokkinakis
+++ b/code/validate_kokkinakis
@@ -109,7 +109,7 @@ MODEL_CLASS = RandomForestClassifier
 K_FOLDS = 5
 RANDOM_STATE = 42
 
-def parallel_loo(
+def parallel_lofo(
     channel_name
 ):
     first_epochs_copy = left_minimap_epochs.copy()
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     assert left_minimap_epochs.ch_names == right_minimap_epochs.ch_names
     channel_names = left_minimap_epochs.ch_names
 
-    results = pqdm(channel_names, parallel_loo, n_jobs=6)
+    results = pqdm(channel_names, parallel_lofo, n_jobs=6)
 
     with open(logs_dir/"rf_validation.json", "wb") as results_file:
         json.dump(results, results_file, indent=4)

--- a/code/validate_kokkinakis
+++ b/code/validate_kokkinakis
@@ -105,6 +105,8 @@ group_labels = {
 #                     kernel="linear"
 # )
 
+
+# These constants have to be somewhat hardcoded due to the need for multiproc functions to be top-level
 MODEL_CLASS = RandomForestClassifier
 K_FOLDS = 5
 RANDOM_STATE = 42
@@ -112,6 +114,31 @@ RANDOM_STATE = 42
 def parallel_lofo(
     channel_name
 ):
+    """
+    parallel_lofo is a function designed to calculate leave-one-feature-out importance 
+    in a parallelised fashion.
+
+    The implementation here is very simple and will produce an output json 
+    that requires further parsing. 
+
+    Note that parallelising this function is very memory heavy, and failure to adequately
+    manage memory will result in numpy array memory errors, which are not currently handled.
+    
+    Usage:
+        Because of the way our current analysis pipeline is set up, this is written with 
+        a requirement for hardcoding the model parameters. Sorry. To this end, see the constants
+        I defined above. You will similarly need to supply constants for any extra args like LOGREG_NUM_ITER. 
+        Once that's done, simply use pqdm as written here (or process pools if you prefer) to compute each
+        feature importance in parallel. 
+
+
+    Args:
+        channel_name (list): this is a list of all the channel names (features) that we want to validate (calculate importance) for. 
+
+    Returns:
+        dict: This function technically returns a single dict of dicts, which contains the usual crossval metrics. 
+            In the usage below, observe that these dicts are stored in a list, resulting from the multiprocessing.
+    """
     first_epochs_copy = left_minimap_epochs.copy()
     second_epochs_copy = right_minimap_epochs.copy()
     
@@ -133,9 +160,11 @@ def parallel_lofo(
 
 if __name__ == "__main__":
 
+    # I think this is a necessary and worthwhile check before running LOFO, since we have two datasets to align.
     assert left_minimap_epochs.ch_names == right_minimap_epochs.ch_names
     channel_names = left_minimap_epochs.ch_names
 
+    # I have chosen to use pqdm to attach a progress bar to this, but using joblib, etc. would be fine too.
     results = pqdm(channel_names, parallel_lofo, n_jobs=6)
 
     with open(logs_dir/"rf_validation.json", "wb") as results_file:

--- a/code/validate_kokkinakis
+++ b/code/validate_kokkinakis
@@ -1,0 +1,142 @@
+import yaml
+import pickle
+from pathlib import Path
+from src import preprocessing, classification, vizualisation, utils, spectral_analysis
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.svm import SVC
+from pqdm.processes import pqdm
+import numpy as np
+from pqdm.processes import pqdm
+import json
+
+# Declare file locations
+# root_dir = Path.home() / "Git" / "minimap_SSVEPs"
+root_dir = Path('G:\workshop\minimap_SSVEPs')
+data_dir = root_dir / "data"
+logs_dir= root_dir / "results" / "kokkinakis"
+fig_dir = root_dir / "results" / "kokkinakis" / "figures"
+params_dir = root_dir / "code" / "conf"
+
+# Load params
+with open(params_dir / "parameters.yaml", 'r') as file:
+    parameters = yaml.safe_load(file)
+# Initialize vizualisation settings
+vizualisation.sns_styleset()
+
+# Get paths for data files
+left_data_folder = preprocessing.get_all_sample_filenames(
+    data_dir / "kokkinakis" / "left_minimap_eeg_data",
+    "edf"
+)
+right_data_folder = preprocessing.get_all_sample_filenames(
+    data_dir / "kokkinakis" / "right_minimap_eeg_data",
+    "edf"
+)
+
+# Load data if already preprocessed
+try:
+    left_minimap_epochs, right_minimap_epochs = utils.load_epochs(data_dir / "kokkinakis" / "epochs.pickle") 
+# Otherwise preprocess it
+except TypeError:
+    left_minimap_epochs = preprocessing.ingest_samples(
+            left_data_folder,
+            parameters["preprocessing"]
+    )
+    right_minimap_epochs = preprocessing.ingest_samples(
+            right_data_folder,
+            parameters["preprocessing"]
+    )
+    # Equalize the number of epochs for each event between the two sets
+    preprocessing.equalize_epoch_counts(
+            left_minimap_epochs,
+            right_minimap_epochs
+    )
+    # Pickle the data for later
+    with open(data_dir / "kokkinakis" / "epochs.pickle", 'wb') as f:
+        pickle.dump([left_minimap_epochs, right_minimap_epochs], f
+        )
+
+
+# Set labels for plots
+group_labels = {
+    left_minimap_epochs: 'left_group',
+    right_minimap_epochs: 'right_group'
+}
+
+
+# ## here we plot time courses of the epochs across conditions
+# for group in [left_minimap_epochs, right_minimap_epochs]:
+#     for freq in ['3.75', '4.8']:
+#         vizualisation.plot_time_course(
+#             epochs = group[f'{freq}_LEFT', f'{freq}_RIGHT'],
+#             ROIs = parameters['analysis']['vROIs'],
+#             group_labels = group_labels,
+#             fig_name = f'{group_labels[group]}_{freq}_average_time_courses_visual_channels',
+#             fig_dir = fig_dir / "time_courses"
+#         )
+
+# ## Here we classify left- versus right- conditioned participants based on their EEG data
+# # Cross-validate classifier and return metrics
+# log_res_metrics = classification.main_analysis(
+#                     left_minimap_epochs,
+#                     right_minimap_epochs,
+#                     LogisticRegression,
+#                     logs_dir,
+#                     random_state=parameters["preprocessing"]["random_state"],
+#                     permutation_test = False,
+#                     max_iter=200
+# )
+# rf_metrics = classification.main_analysis(
+#                     left_minimap_epochs,
+#                     right_minimap_epochs,
+#                     RandomForestClassifier,
+#                     logs_dir,
+#                     random_state=parameters["preprocessing"]["random_state"],
+#                     permutation_test = False
+# )
+# svm_metrics = classification.main_analysis(
+#                     left_minimap_epochs,
+#                     right_minimap_epochs,
+#                     SVC,
+#                     logs_dir,
+#                     random_state=parameters["preprocessing"]["random_state"],
+#                     permutation_test = False,
+#                     kernel="linear"
+# )
+
+MODEL_CLASS = RandomForestClassifier
+K_FOLDS = 5
+RANDOM_STATE = 42
+
+def parallel_loo(
+    channel_name
+):
+    first_epochs_copy = left_minimap_epochs.copy()
+    second_epochs_copy = right_minimap_epochs.copy()
+    
+    first_epochs_copy.drop_channels(channel_name, "warn")
+    second_epochs_copy.drop_channels(channel_name, "warn")
+
+    X_first = classification.compute_psd_and_features(first_epochs_copy) 
+    X_second = classification.compute_psd_and_features(second_epochs_copy)
+    X = np.vstack([X_first, X_second])
+    y = classification.create_labels_for_binary_classification(
+        len(first_epochs_copy.events),
+        len(second_epochs_copy.events),
+    )
+    # Perform cross-validation on the training set
+    cv_results = classification.perform_cross_validation(X, y, MODEL_CLASS, K_FOLDS, RANDOM_STATE)
+    cv_metrics = classification.parse_cv_results(cv_results, K_FOLDS)
+    out = {channel_name: cv_metrics}
+    return out
+
+if __name__ == "__main__":
+
+    assert left_minimap_epochs.ch_names == right_minimap_epochs.ch_names
+    channel_names = left_minimap_epochs.ch_names
+
+    results = pqdm(channel_names, parallel_loo, n_jobs=6)
+
+    with open(logs_dir/"rf_validation.json", "wb") as results_file:
+        json.dump(results, results_file, indent=4)


### PR DESCRIPTION
This is a prototype script which computes the same model with a single channel dropped at a time, over all channels in our dataset. I originally called this LOO, but then....

Truthfully, I had made it most of the way through this before I realised this existed already-- I should've known better. The existing library can be found [here](https://github.com/aerdem4/lofo-importance).

In any case, I finished the script anyway because it didn't seem *completely* different from this third party package.

The way this approach works is to simply verify that the two conditions have identical channel names, then a `None` channel type is prepended as a control, and it proceeds with the same analysis as would've run previously. 

A few comments:

1. There are some anti-patterns here which I am not fond of, but as far as I can tell, it run on my machine™ . I will follow up this comment with a code review where I mark various things that may be worth addressing. 
2. For LOFO, I have opted to run the same cross validation scheme. To be honest I had no basis for this other than a hunch, and I'm not sure it's entirely necessary. However, the lofo-importance library also seems to do this. Let me know what you think.
3. Our dataset is of non-trivial size for consumer PCs. I can't run this analysis with more than 4 processes at a time, because I quickly run out of memory. If possible, please run this on some kind of cluster. 
4. The output is both a pickle and a CSV of LOFO results. I opted for the CSV to have  a quickly readable and sortable structure. 
5. I did this over the `analyse_kokkinakis.py` script, and specifically just for the random forest, for a few reasons: it was the most performant model, and it meant I could avoid dealing with kwargs.

Code review to follow.